### PR TITLE
use gpgme.dev in native messaging host json file since gpgme-json only exists in .dev package

### DIFF
--- a/modules/home-manager/cli/gpg.nix
+++ b/modules/home-manager/cli/gpg.nix
@@ -104,7 +104,7 @@ in {
       in toJSON.generate "gpgmejson.json" {
         name = "gpgmejson";
         description = "JavaScript binding for GnuPG";
-        path = "${pkgs.gpgme}/bin/gpgme-json";
+        path = "${pkgs.gpgme.dev}/bin/gpgme-json";
         type = "stdio";
         allowed_extensions = [ "jid1-AQqSMBYb0a8ADg@jetpack" ];
       };


### PR DESCRIPTION
i was searching how other people did mailvelope in nixos and i came across your repo
but when i created json using your method it didnt worked. when i looked into it it was because
gpgme package doesnt include gpgme-json program so it doesnt work but gpgme.dev package include it.

i hope it helps you
